### PR TITLE
ci: prevent a release when @ridedott/eslint-config is updated

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -30,6 +30,10 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - name: Release
+        # Prevent version bumps of @ridedott/eslint-config from triggering a release.
+        if:
+          contains(github.event.commits[0].message, 'chore(deps-dev)&#58; bump
+          @ridedott/eslint-config') == false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_DOTTBOTT }}
         id: build_package


### PR DESCRIPTION
This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.
- [x] Does not introduce cycles into the flow of execution.

### Context
we have 2 repos `eslint-config` and `eslint-plugin` .
`eslint-config`  is a dev dependency in` eslint-plugin` .
`eslint-plugin`  is a dependency in `eslint-config` .
The problem is that a release on any would trigger a release cycle with our current set up, this PR prevents that.