### PR TITLE
fix: support tagged templates in no-template-literals-without-expression

### DIFF
--- a/documentation/rules/no-template-literals-without-expression.md
+++ b/documentation/rules/no-template-literals-without-expression.md
@@ -28,6 +28,10 @@ Examples of **correct** code for this rule:
 with ${expression}`;
 
 `Single line template literal without expressions, 'single quotes', "double quotes"`;
+
+tag`string text`;
+
+tag`string text line 1 \n string text line 2`;
 ```
 
 ## Options

--- a/src/rules/no-template-literals-without-expression.ts
+++ b/src/rules/no-template-literals-without-expression.ts
@@ -1,6 +1,68 @@
-import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  AST_NODE_TYPES,
+  TSESLint,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
 
 import { createRule } from '../util';
+
+const verifyTemplateLiteral = (
+  node: TSESTree.TemplateLiteral,
+  /* eslint-disable @typescript-eslint/typedef */
+  context,
+  /* eslint-enable @typescript-eslint/typedef */
+  ignoreMultiline: boolean,
+): void => {
+  const [valueHasSingleQuotes, valueHasDoubleQuotes] = node.quasis.reduce(
+    (acc: boolean[], curr: TSESTree.TemplateElement): boolean[] => {
+      return [
+        acc[0] === false ? curr.value.raw.includes("'") : acc[0],
+        acc[1] === false ? curr.value.raw.includes('"') : acc[1],
+      ];
+    },
+    [false, false],
+  );
+  const hasNoExpressions = node.expressions.length === 0;
+  const isMultiline = node.loc.start.line !== node.loc.end.line;
+
+  const ruleFixer = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix[] => {
+    if (valueHasSingleQuotes === true) {
+      return [
+        fixer.replaceTextRange([node.range[0], node.range[0] + 1], '"'),
+        fixer.replaceTextRange([node.range[1] - 1, node.range[1]], '"'),
+      ];
+    }
+
+    return [
+      fixer.replaceTextRange([node.range[0], node.range[0] + 1], "'"),
+      fixer.replaceTextRange([node.range[1] - 1, node.range[1]], "'"),
+    ];
+  };
+
+  if (
+    (isMultiline === true && ignoreMultiline === true) ||
+    (valueHasSingleQuotes === true && valueHasDoubleQuotes === true)
+  ) {
+    return;
+  }
+
+  if (hasNoExpressions === true) {
+    if (isMultiline === false) {
+      context.report({
+        messageId: 'templateLiteralsShouldHaveExpression',
+        loc: node.loc,
+        fix: ruleFixer,
+      });
+    }
+
+    if (isMultiline === true) {
+      context.report({
+        messageId: 'templateLiteralsShouldHaveExpression',
+        loc: node.loc,
+      });
+    }
+  }
+};
 
 export default createRule({
   name: __filename,
@@ -37,58 +99,16 @@ export default createRule({
       ignoreMultiline: boolean;
     }>,
   ): {
-    TemplateLiteral(node: TSESTree.TemplateLiteral): void;
+    ExpressionStatement(node: TSESTree.ExpressionStatement): void;
   } {
     return {
-      TemplateLiteral(node: TSESTree.TemplateLiteral): void {
-        const [valueHasSingleQuotes, valueHasDoubleQuotes] = node.quasis.reduce(
-          (acc: boolean[], curr: TSESTree.TemplateElement): boolean[] => {
-            return [
-              acc[0] === false ? curr.value.raw.includes("'") : acc[0],
-              acc[1] === false ? curr.value.raw.includes('"') : acc[1],
-            ];
-          },
-          [false, false],
-        );
-        const hasNoExpressions = node.expressions.length === 0;
-        const isMultiline = node.loc.start.line !== node.loc.end.line;
-
-        const ruleFixer = (fixer: TSESLint.RuleFixer): TSESLint.RuleFix[] => {
-          if (valueHasSingleQuotes === true) {
-            return [
-              fixer.replaceTextRange([node.range[0], node.range[0] + 1], '"'),
-              fixer.replaceTextRange([node.range[1] - 1, node.range[1]], '"'),
-            ];
-          }
-
-          return [
-            fixer.replaceTextRange([node.range[0], node.range[0] + 1], "'"),
-            fixer.replaceTextRange([node.range[1] - 1, node.range[1]], "'"),
-          ];
-        };
-
-        if (
-          (isMultiline === true && ignoreMultiline === true) ||
-          (valueHasSingleQuotes === true && valueHasDoubleQuotes === true)
-        ) {
+      ExpressionStatement(node: TSESTree.ExpressionStatement): void {
+        if (node.expression.type === AST_NODE_TYPES.TaggedTemplateExpression) {
           return;
         }
 
-        if (hasNoExpressions === true) {
-          if (isMultiline === false) {
-            context.report({
-              messageId: 'templateLiteralsShouldHaveExpression',
-              loc: node.loc,
-              fix: ruleFixer,
-            });
-          }
-
-          if (isMultiline === true) {
-            context.report({
-              messageId: 'templateLiteralsShouldHaveExpression',
-              loc: node.loc,
-            });
-          }
+        if (node.expression.type === AST_NODE_TYPES.TemplateLiteral) {
+          verifyTemplateLiteral(node.expression, context, ignoreMultiline);
         }
       },
     };

--- a/test/rules/no-template-literals-without-expression.spec.ts
+++ b/test/rules/no-template-literals-without-expression.spec.ts
@@ -54,5 +54,7 @@ ruleTester.run('no-template-literals-without-expression', rule, {
       code: '`Multiline template literal\nwithout expressions`',
       options: [{ ignoreMultiline: true }],
     },
+    'tag`string text line 1 \n string text line 2`;',
+    'tag`string text`;',
   ],
 });


### PR DESCRIPTION
This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.
- [x] Does not introduce cycles into the flow of execution.

This PR adds support for tagged templates in `no-template-literals-without-expression` rule.
