### PR TITLE
chore: switch to non-experimental utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@ridedott/eslint-plugin",
-      "version": "1.6.286",
+      "version": "1.6.287",
       "license": "UNLICENSED",
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "^5.13.0",
-        "@typescript-eslint/parser": "^5.13.0"
+        "@typescript-eslint/parser": "^5.13.0",
+        "@typescript-eslint/utils": "^5.13.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^16.2.1",
@@ -2245,24 +2245,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.13.0.tgz",
-      "integrity": "sha512-A0btJxjB9gH6yJsARONe5xd0ykgj1+0fO1TRWoUBn2hT3haWiZeh4f1FILKW0z/9OBchT5zCOz3hiJfRK/vumA==",
-      "dependencies": {
-        "@typescript-eslint/utils": "5.13.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -13854,14 +13836,6 @@
             "tsutils": "^3.17.1"
           }
         }
-      }
-    },
-    "@typescript-eslint/experimental-utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.13.0.tgz",
-      "integrity": "sha512-A0btJxjB9gH6yJsARONe5xd0ykgj1+0fO1TRWoUBn2hT3haWiZeh4f1FILKW0z/9OBchT5zCOz3hiJfRK/vumA==",
-      "requires": {
-        "@typescript-eslint/utils": "5.13.0"
       }
     },
     "@typescript-eslint/parser": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     }
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^5.13.0",
-    "@typescript-eslint/parser": "^5.13.0"
+    "@typescript-eslint/parser": "^5.13.0",
+    "@typescript-eslint/utils": "^5.13.0"
   },
   "description": "ESLint plugin for custom rules.",
   "devDependencies": {

--- a/src/rules/no-single-line-comment-block.ts
+++ b/src/rules/no-single-line-comment-block.ts
@@ -1,8 +1,4 @@
-import {
-  AST_TOKEN_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_TOKEN_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 

--- a/src/rules/no-template-literals-without-expression.ts
+++ b/src/rules/no-template-literals-without-expression.ts
@@ -1,8 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 
 import { createRule } from '../util';
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable new-cap */
 
-import { ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
 import { parse as parsePath } from 'path';
 
 /**

--- a/test/rules/no-single-line-comment-block.spec.ts
+++ b/test/rules/no-single-line-comment-block.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/filename-case */
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 import rule from '../../src/rules/no-single-line-comment-block';
 

--- a/test/rules/no-template-literals-without-expression.spec.ts
+++ b/test/rules/no-template-literals-without-expression.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-template-curly-in-string */
 /* eslint-disable unicorn/filename-case */
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 
 import rule from '../../src/rules/no-template-literals-without-expression';
 


### PR DESCRIPTION
Like it says on the npm package [page](https://www.npmjs.com/package/@typescript-eslint/experimental-utils), the utils are no longer experimental, and `experimental-utils` are just a re-export of a regular package now. In the next major version of this package they will warn us about switching anyway.

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [x] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.
- [x] Does not introduce cycles into the flow of execution.

<!--
Example: Resolves #1234

This allows PRs to be resolved automatically once the PR is merged to a base
branch. The following line should be removed if the PR does not affect any open
issues.
-->

<!--
Link to a PR with a documentation update:
-->
