### PR TITLE
feat: update node to v14

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,7 +22,7 @@ updates:
     ignore:
       - dependency-name: '@types/node'
         versions:
-          - '> 12'
+          - '> 14'
     open-pull-requests-limit: 99
     package-ecosystem: npm
     reviewers:

--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -19,14 +19,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          key: npm-${{ hashFiles('./package-lock.json') }}
-          path: ~/.npm
-          restore-keys: |
-            npm-
+          cache: 'npm'
+          node-version: 14
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - name: Build

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -20,14 +20,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          key: npm-${{ hashFiles('./package-lock.json') }}
-          path: ~/.npm
-          restore-keys: |
-            npm-
+          cache: 'npm'
+          node-version: 14
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - name: Format
@@ -44,14 +38,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          key: npm-${{ hashFiles('./package-lock.json') }}
-          path: ~/.npm
-          restore-keys: |
-            npm-
+          cache: 'npm'
+          node-version: 14
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - name: Lint
@@ -68,14 +56,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          key: npm-${{ hashFiles('./package-lock.json') }}
-          path: ~/.npm
-          restore-keys: |
-            npm-
+          cache: 'npm'
+          node-version: 14
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - name: Spellcheck
@@ -92,14 +74,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          key: npm-${{ hashFiles('./package-lock.json') }}
-          path: ~/.npm
-          restore-keys: |
-            npm-
+          cache: 'npm'
+          node-version: 14
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - name: Test
@@ -120,14 +96,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 12
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          key: npm-${{ hashFiles('./package-lock.json') }}
-          path: ~/.npm
-          restore-keys: |
-            npm-
+          cache: 'npm'
+          node-version: 14
       - name: Install dependencies
         run: npm ci --ignore-scripts --no-audit --no-progress --prefer-offline
       - name: Types

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ consume this package in your project.
 
 Minimal requirements to set up the project:
 
-- [Node.js](https://nodejs.org/en) v12, installation instructions can be found
+- [Node.js](https://nodejs.org/en) v14, installation instructions can be found
   on the official website, a recommended installation option is to use
   [Node Version Manager](https://github.com/creationix/nvm#readme). It can be
   installed in a

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@ridedott/eslint-plugin",
-      "version": "1.6.354",
+      "version": "1.6.355",
       "license": "UNLICENSED",
       "dependencies": {
         "@typescript-eslint/parser": "^5.31.0",
@@ -17,7 +17,7 @@
         "@commitlint/config-conventional": "^17.0.3",
         "@ridedott/eslint-config": "^2.13.12",
         "@types/jest": "^27.5.0",
-        "@types/node": "^12.20.11",
+        "@types/node": "^14.18.22",
         "commitizen": "^4.2.5",
         "cspell": "^5.21.0",
         "eslint": "^7.32.0",
@@ -31,7 +31,7 @@
         "typescript": "^4.7.4"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2181,9 +2181,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.11.tgz",
-      "integrity": "sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==",
+      "version": "14.18.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.22.tgz",
+      "integrity": "sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -13550,9 +13550,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.11.tgz",
-      "integrity": "sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==",
+      "version": "14.18.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.22.tgz",
+      "integrity": "sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@ridedott/eslint-plugin",
-      "version": "1.6.351",
+      "version": "1.6.352",
       "license": "UNLICENSED",
       "dependencies": {
         "@typescript-eslint/parser": "^5.30.7",
@@ -17,7 +17,7 @@
         "@commitlint/config-conventional": "^17.0.3",
         "@ridedott/eslint-config": "^2.13.12",
         "@types/jest": "^27.5.0",
-        "@types/node": "^12.20.11",
+        "@types/node": "^14.18.22",
         "commitizen": "^4.2.5",
         "cspell": "^5.21.0",
         "eslint": "^7.32.0",
@@ -31,7 +31,7 @@
         "typescript": "^4.7.4"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2181,9 +2181,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.11.tgz",
-      "integrity": "sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==",
+      "version": "14.18.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.22.tgz",
+      "integrity": "sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -13550,9 +13550,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.11.tgz",
-      "integrity": "sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==",
+      "version": "14.18.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.22.tgz",
+      "integrity": "sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@commitlint/config-conventional": "^17.0.3",
     "@ridedott/eslint-config": "^2.13.12",
     "@types/jest": "^27.5.0",
-    "@types/node": "^12.20.11",
+    "@types/node": "^14.18.22",
     "commitizen": "^4.2.5",
     "cspell": "^5.21.0",
     "eslint": "^7.32.0",
@@ -28,7 +28,7 @@
     "typescript": "^4.7.4"
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "files": [
     "lib",


### PR DESCRIPTION
I wasn't sure if it should be updated to v16, as some of our repositories don't use it yet (for example, firestore-schema), but v12 is end-of-life already, so I think we can update at least to that. This would also unblock updates for some packages (for example [this one](https://github.com/ridedott/eslint-plugin/pull/1009)) because they also are dropping node v12 support.

This Pull Request fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [ ] Tests for the changes have been added if needed.
- [x] Does not affect documentation or it has been added or updated.
- [x] Does not introduce cycles into the flow of execution.

<!--
Example: Resolves #1234

This allows PRs to be resolved automatically once the PR is merged to a base
branch. The following line should be removed if the PR does not affect any open
issues.
-->

Resolves #

<!--
Link to a PR with a documentation update:
-->
